### PR TITLE
Update license link in README.md on v0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Leptos Support](https://img.shields.io/badge/Leptos%20Support-v0.7%20to%20v0.8-informational)
 [![docs.rs](https://img.shields.io/docsrs/leptos-pdf)](https://docs.rs/leptos-pdf)
 [![crates.io downloads](https://img.shields.io/crates/d/leptos-pdf.svg)](https://crates.io/crates/leptos-pdf)
-[![license](https://img.shields.io/crates/l/leptos-pdf.svg)](https://github.com/your-org/leptos-pdf/blob/main/LICENSE)  
+[![license](https://img.shields.io/crates/l/leptos-pdf.svg)](https://github.com/dmanuel64/leptos-pdf/blob/master/LICENSE)  
 ![Maintenance](https://img.shields.io/maintenance/yes/2025)
 
 


### PR DESCRIPTION
## Summary
Updated the License badge in the README to point to the correct GitHub repository instead of the placeholder link.

## Checklist

- [x] Follows Conventional Commits (e.g., `feat:`, `fix:`, `chore:`)
- [ ] Tests added/updated (if applicable)
- [x] Documentation updated (if applicable)
- [x] Ready to be reviewed and merged

## What’s Changed

Replaced placeholder GitHub URL in the license badge with the correct link:
https://github.com/dmanuel64/leptos-pdf/blob/master/LICENSE

## Notes for Reviewers

Only the README license badge link was changed; no functional code changes.

Closes #15 